### PR TITLE
Apply Atom One Dark theme to UI

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -9,8 +9,8 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
+    --background: #282c34;
+    --foreground: #abb2bf;
   }
 }
 
@@ -236,15 +236,15 @@ iframe {
   blockquote {
     margin-top: 2rem;
     margin-bottom: 2rem;
-    border-left: 4px solid #63e6be;
+    border-left: 4px solid #98c379;
     border-top-right-radius: 4px;
     border-bottom-right-radius: 4px;
-    background: #1e1e1e;
+    background: #21252b;
     margin-left: 0;
     margin-right: 0;
     padding: 1rem;
     padding-left: 2rem;
-    color: #ececec;
+    color: #abb2bf;
     ul,
     ol {
       padding-left: 1rem;
@@ -262,7 +262,7 @@ iframe {
    */
 
   pre {
-    background: #383e49;
+    background: #282c34;
   }
   /**
   * prism.js default theme for JavaScript, CSS and HTML
@@ -319,7 +319,7 @@ iframe {
 
   :not(pre) > code[class*="language-"],
   pre[class*="language-"] {
-    background: #1e1e1e;
+    background: #282c34;
   }
 
   /* Inline code */
@@ -487,10 +487,10 @@ iframe {
     }
 
     tr:nth-child(even) {
-      background: #1e1e1e;
+      background: #282c34;
     }
     tr:nth-child(odd) {
-      background: #121212;
+      background: #21252b;
     }
   }
 

--- a/components/atoms/Button.module.css
+++ b/components/atoms/Button.module.css
@@ -10,19 +10,31 @@
 
 /* Variants */
 .primary {
-  background-color: #007bff;
-  color: white;
+  background-color: #61afef;
+  color: #282c34;
+}
+
+.primary:hover {
+  background-color: #4d8cd6;
 }
 
 .secondary {
-  background-color: #6c757d;
-  color: white;
+  background-color: #c678dd;
+  color: #282c34;
+}
+
+.secondary:hover {
+  background-color: #a75ac7;
 }
 
 .tertiary {
   background-color: transparent;
-  color: #007bff;
-  border: 1px solid #007bff;
+  color: #61afef;
+  border: 1px solid #61afef;
+}
+
+.tertiary:hover {
+  background-color: rgba(97, 175, 239, 0.1);
 }
 
 /* Sizes */
@@ -43,7 +55,7 @@
 
 /* Disabled state */
 .button:disabled {
-  background-color: #e0e0e0;
-  color: #a0a0a0;
+  background-color: #5c6370;
+  color: #282c34;
   cursor: not-allowed;
 }

--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -61,22 +61,34 @@ export const darkTheme = createTheme({
   palette: {
     mode: "dark",
     primary: {
-      main: "#3b82f6", // blue-500
-      light: "#60a5fa", // blue-400
-      dark: "#2563eb", // blue-600
+      main: "#61afef", // Atom One Dark blue
+      light: "#84c1ff",
+      dark: "#4d8cd6",
     },
     secondary: {
-      main: "#8b5cf6", // violet-500
-      light: "#a78bfa", // violet-400
-      dark: "#7c3aed", // violet-600
+      main: "#c678dd", // Atom One Dark purple
+      light: "#d89fea",
+      dark: "#a75ac7",
     },
     background: {
-      default: "#0f172a", // slate-900
-      paper: "#1e293b", // slate-800
+      default: "#282c34", // Atom One Dark main background
+      paper: "#21252b", // Atom One Dark darker background
     },
     text: {
-      primary: "#f1f5f9", // slate-100
-      secondary: "#94a3b8", // slate-400
+      primary: "#abb2bf", // Atom One Dark foreground
+      secondary: "#5c6370", // Atom One Dark comment gray
+    },
+    error: {
+      main: "#e06c75", // Atom One Dark red
+    },
+    warning: {
+      main: "#e5c07b", // Atom One Dark yellow
+    },
+    success: {
+      main: "#98c379", // Atom One Dark green
+    },
+    info: {
+      main: "#56b6c2", // Atom One Dark cyan
     },
   },
   typography: {
@@ -91,7 +103,7 @@ export const darkTheme = createTheme({
       styleOverrides: {
         root: {
           boxShadow: "0 1px 3px 0 rgb(0 0 0 / 0.3)",
-          backgroundColor: "#1e293b",
+          backgroundColor: "#21252b",
         },
       },
     },
@@ -100,7 +112,7 @@ export const darkTheme = createTheme({
         root: {
           borderRadius: 12,
           boxShadow: "0 1px 3px 0 rgb(0 0 0 / 0.3)",
-          backgroundColor: "#1e293b",
+          backgroundColor: "#21252b",
         },
       },
     },
@@ -110,6 +122,13 @@ export const darkTheme = createTheme({
           borderRadius: 8,
           textTransform: "none",
           fontWeight: 600,
+        },
+      },
+    },
+    MuiPaper: {
+      styleOverrides: {
+        root: {
+          backgroundColor: "#21252b",
         },
       },
     },


### PR DESCRIPTION
- Material-UI 다크 테마를 Atom One Dark 색상 팔레트로 변경
  - 배경: #282c34 (메인), #21252b (다크)
  - 텍스트: #abb2bf (주요), #5c6370 (보조)
  - 주요 색상: #61afef (파란색), #c678dd (보라색)
  - 상태 색상: #e06c75 (에러), #e5c07b (경고), #98c379 (성공), #56b6c2 (정보)
- globals.css의 다크모드 CSS 변수 업데이트
- Button.module.css를 Atom One Dark 색상으로 변경

🤖 Generated with [Claude Code](https://claude.com/claude-code)