### PR TITLE
feat: private notes 페이지 추가

### DIFF
--- a/app/api/posts/route.ts
+++ b/app/api/posts/route.ts
@@ -1,20 +1,28 @@
-import { NextResponse } from "next/server"
+import { NextRequest, NextResponse } from "next/server"
 import fs from "fs"
 import path from "path"
 import type { BlogPost, ErrorResponse } from "@/types/api"
 
-export async function GET(): Promise<NextResponse<BlogPost[] | ErrorResponse>> {
+export async function GET(request: NextRequest): Promise<NextResponse<BlogPost[] | ErrorResponse>> {
   try {
-    const postsDirectory = path.join(process.cwd(), "markdown")
+    const dir = request.nextUrl.searchParams.get("dir")
+    const subDir = dir === "private" ? "private" : ""
+    const postsDirectory = path.join(process.cwd(), "markdown", subDir)
+
+    if (!fs.existsSync(postsDirectory)) {
+      return NextResponse.json([])
+    }
+
     const fileNames = fs.readdirSync(postsDirectory)
 
-    const HIDDEN = ["how", "economies_700", "intro"]
+    const HIDDEN = subDir ? [] : ["how", "economies_700", "intro"]
+    const ext = subDir === "private" ? ".html" : ".md"
 
     const posts: BlogPost[] = fileNames
-      .filter((fileName) => fileName.endsWith(".md") && !HIDDEN.some((h) => fileName.includes(h)))
+      .filter((fileName) => fileName.endsWith(ext) && !HIDDEN.some((h) => fileName.includes(h)))
       .map((fileName) => ({
-        title: fileName.replace(/\.md$/, ""),
-        link: fileName.replace(/\.md$/, ""),
+        title: fileName.replace(new RegExp(`\\${ext}$`), ""),
+        link: fileName.replace(new RegExp(`\\${ext}$`), ""),
       }))
 
     return NextResponse.json(posts)

--- a/app/private/[slug]/page.tsx
+++ b/app/private/[slug]/page.tsx
@@ -1,0 +1,26 @@
+import fs from "fs"
+import path from "path"
+
+export function generateStaticParams() {
+  const dir = path.join(process.cwd(), "markdown", "private")
+  if (!fs.existsSync(dir)) return []
+
+  return fs
+    .readdirSync(dir)
+    .filter((f) => f.endsWith(".html"))
+    .map((f) => ({ slug: f.replace(/\.html$/, "") }))
+}
+
+interface Props {
+  params: Promise<{ slug: string }>
+}
+
+export default async function PrivatePost({ params }: Props) {
+  const { slug } = await params
+  const filePath = path.join(process.cwd(), "markdown", "private", `${decodeURIComponent(slug)}.html`)
+  const html = fs.readFileSync(filePath, "utf-8")
+
+  return (
+    <div className="mark-down" dangerouslySetInnerHTML={{ __html: html }} />
+  )
+}

--- a/app/private/layout.tsx
+++ b/app/private/layout.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import { Box, Typography } from "@mui/material"
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+import { ArrowBack } from "@mui/icons-material"
+
+export default function PrivateLayout({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname()
+  const isDetail = pathname !== "/private"
+
+  return (
+    <>
+      <style>{`
+        nav.fixed { display: none !important; }
+        main { padding-top: 0 !important; }
+      `}</style>
+      <Box sx={{ py: 1.5, mb: 1, display: "flex", alignItems: "center", gap: 1 }}>
+        {isDetail ? (
+          <Link href="/private" style={{ color: "inherit", display: "flex", alignItems: "center", gap: 4 }}>
+            <ArrowBack sx={{ fontSize: 20 }} />
+            <Typography variant="body2">목록</Typography>
+          </Link>
+        ) : (
+          <Typography variant="body2" sx={{ opacity: 0.5 }}>Private</Typography>
+        )}
+      </Box>
+      {children}
+    </>
+  )
+}

--- a/app/private/page.tsx
+++ b/app/private/page.tsx
@@ -1,0 +1,58 @@
+"use client"
+
+import { Box, Typography, Skeleton, Pagination } from "@mui/material"
+import BlogCard from "@/components/organisms/BlogCard"
+import { useEffect, useState } from "react"
+import { ErrorBoundary } from "@/components/atoms/ErrorBoundary"
+import type { BlogType } from "@/components/templates/MarkdownTemplate"
+
+const PAGE_SIZE = 10
+
+export default function PrivatePage() {
+  const [posts, setPosts] = useState<BlogType[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [page, setPage] = useState(1)
+
+  useEffect(() => {
+    fetch("/api/posts?dir=private")
+      .then((res) => res.json())
+      .then((data) => setPosts(Array.isArray(data) ? data : []))
+      .catch(() => setPosts([]))
+      .finally(() => setIsLoading(false))
+  }, [])
+
+  const totalPages = Math.ceil(posts.length / PAGE_SIZE)
+  const paginated = posts.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE)
+
+  return (
+    <Box sx={{ mb: 6 }}>
+      <Typography variant="h4" gutterBottom fontWeight={700} sx={{ mb: 3 }}>
+        🔒 Private Notes
+      </Typography>
+      <ErrorBoundary>
+        {isLoading ? (
+          <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
+            {[1, 2, 3].map((i) => (
+              <Skeleton key={i} variant="text" width="60%" height={32} sx={{ bgcolor: "grey.500" }} />
+            ))}
+          </Box>
+        ) : posts.length ? (
+          <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+            {paginated.map((post) => (
+              <BlogCard key={post.title} blog={post} basePath="/private" />
+            ))}
+            {totalPages > 1 && (
+              <Box sx={{ display: "flex", justifyContent: "center", mt: 2 }}>
+                <Pagination count={totalPages} page={page} onChange={(_, v) => setPage(v)} color="primary" shape="rounded" />
+              </Box>
+            )}
+          </Box>
+        ) : (
+          <Typography variant="body1" color="text.secondary" sx={{ textAlign: "center", py: 4 }}>
+            문서가 없습니다.
+          </Typography>
+        )}
+      </ErrorBoundary>
+    </Box>
+  )
+}

--- a/components/organisms/BlogCard.tsx
+++ b/components/organisms/BlogCard.tsx
@@ -5,12 +5,12 @@ import { useRouter } from "next/navigation"
 import { BlogType } from "../templates/MarkdownTemplate"
 import { ArrowForward } from "@mui/icons-material"
 
-const BlogCard = ({ blog }: { blog: BlogType }) => {
+const BlogCard = ({ blog, basePath = "/md" }: { blog: BlogType; basePath?: string }) => {
   const router = useRouter()
 
   return (
     <Card
-      onClick={() => router.push("/md/" + blog.link)}
+      onClick={() => router.push(basePath + "/" + blog.link)}
       sx={{
         cursor: "pointer",
         transition: "all 0.3s ease",

--- a/markdown/private/camping.html
+++ b/markdown/private/camping.html
@@ -1,0 +1,238 @@
+<style>
+  .camp-wrap { display: flex; flex-direction: column; gap: 16px; }
+  .camp-card {
+    border: 1px solid rgba(128,128,128,0.3);
+    border-radius: 12px;
+    padding: 16px;
+    background: rgba(128,128,128,0.06);
+  }
+  .camp-header {
+    margin: 0 0 12px 0;
+  }
+  .camp-title {
+    font-size: 1.25rem;
+    font-weight: 700;
+    margin: 0 0 6px 0;
+  }
+  .camp-links {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+  .camp-link {
+    font-size: 0.78rem;
+    padding: 2px 10px;
+    border-radius: 6px;
+    text-decoration: none;
+    font-weight: 500;
+  }
+  .camp-link--reserve {
+    background: #1565c0;
+    color: #fff;
+  }
+  .dark .camp-link--reserve {
+    background: #1e88e5;
+  }
+  .camp-link--search {
+    background: #2db400;
+    color: #fff;
+  }
+  .camp-link--blog {
+    background: #757575;
+    color: #fff;
+  }
+  .dark .camp-link--blog {
+    background: #616161;
+  }
+  .camp-info {
+    display: grid;
+    grid-template-columns: 80px 1fr;
+    gap: 6px 12px;
+    font-size: 0.9rem;
+    margin-bottom: 12px;
+  }
+  .camp-info dt { opacity: 0.55; font-weight: 500; }
+  .camp-info dd { margin: 0; }
+  .camp-total {
+    font-size: 1.1rem;
+    font-weight: 700;
+    color: #2e7d32;
+    margin-bottom: 10px;
+  }
+  .dark .camp-total { color: #66bb6a; }
+  .camp-tags { display: flex; flex-wrap: wrap; gap: 6px; }
+  .camp-tag {
+    font-size: 0.75rem;
+    font-weight: 700;
+    padding: 3px 10px;
+    border-radius: 999px;
+    background: rgba(21,101,192,0.1);
+    color: #1565c0;
+  }
+  .dark .camp-tag {
+    background: rgba(144,202,249,0.15);
+    color: #90caf9;
+  }
+  .camp-subtitle { opacity: 0.5; font-size: 0.85rem; margin-bottom: 20px; }
+</style>
+
+<h1 style="font-size:1.5rem; font-weight:700; margin-bottom:4px;">⛺ 캠핑장 비교</h1>
+<p class="camp-subtitle">7월 15일(화) ~ 16일(수) · 상동역 기준 · 입실 15:00 ~ 퇴실 11:00</p>
+
+<div class="camp-wrap">
+
+  <!-- 리틀포레스트캠핑 -->
+  <div class="camp-card">
+    <div class="camp-header">
+      <div class="camp-title">🌲 리틀포레스트캠핑</div>
+      <div class="camp-links">
+        <a class="camp-link camp-link--reserve" href="https://naver.me/5VmQSfaA" target="_blank" rel="noopener">예약</a>
+        <a class="camp-link camp-link--search" href="https://search.naver.com/search.naver?query=%EB%A6%AC%ED%8B%80%ED%8F%AC%EB%A0%88%EC%8A%A4%ED%8A%B8%EC%BA%A0%ED%95%91" target="_blank" rel="noopener">네이버</a>
+        <a class="camp-link camp-link--blog" href="https://blog.naver.com/dusmldl/224261253539" target="_blank" rel="noopener">후기</a>
+      </div>
+    </div>
+    <div class="camp-info">
+      <dt>숙박</dt><dd>248,000원</dd>
+      <dt>바베큐</dt><dd>무료</dd>
+      <dt>위치</dt><dd>가평군 91km (1시간 21분)</dd>
+      <dt>통행료</dt><dd>4,100원</dd>
+      <dt>연료비</dt><dd>17,000원</dd>
+    </div>
+    <div class="camp-total">총 예상: 269,100원</div>
+    <div class="camp-tags">
+      <span class="camp-tag">캠핑카</span>
+      <span class="camp-tag">턴테이블</span>
+      <span class="camp-tag">빔프로젝터</span>
+      <span class="camp-tag">개별욕실</span>
+      <span class="camp-tag">공용샤워실</span>
+      <span class="camp-tag">조식무료</span>
+      <span class="camp-tag">산</span>
+    </div>
+  </div>
+
+  <!-- 아웃오브파크 -->
+  <div class="camp-card">
+    <div class="camp-header">
+      <div class="camp-title">🏕️ 아웃오브파크</div>
+      <div class="camp-links">
+        <a class="camp-link camp-link--reserve" href="https://naver.me/F884bQQi" target="_blank" rel="noopener">예약</a>
+        <a class="camp-link camp-link--search" href="https://search.naver.com/search.naver?query=%EC%95%84%EC%9B%83%EC%98%A4%EB%B8%8C%ED%8C%8C%ED%81%AC" target="_blank" rel="noopener">네이버</a>
+      </div>
+    </div>
+    <div class="camp-info">
+      <dt>숙박</dt><dd>175,000원</dd>
+      <dt>바베큐</dt><dd>25,000원</dd>
+      <dt>위치</dt><dd>가평군 91km (1시간 49분)</dd>
+      <dt>통행료</dt><dd>6,300원</dd>
+      <dt>연료비</dt><dd>19,000원</dd>
+    </div>
+    <div class="camp-total">총 예상: 225,300원</div>
+    <div class="camp-tags">
+      <span class="camp-tag">카라반</span>
+      <span class="camp-tag">개별욕실</span>
+      <span class="camp-tag">호수</span>
+    </div>
+  </div>
+
+  <!-- 올덴카라반 -->
+  <div class="camp-card">
+    <div class="camp-header">
+      <div class="camp-title">🚐 올덴카라반</div>
+      <div class="camp-links">
+        <a class="camp-link camp-link--reserve" href="https://naver.me/xTT6xal8" target="_blank" rel="noopener">예약</a>
+        <a class="camp-link camp-link--search" href="https://search.naver.com/search.naver?query=%EC%98%AC%EB%8D%B4%EC%B9%B4%EB%9D%BC%EB%B0%98" target="_blank" rel="noopener">네이버</a>
+      </div>
+    </div>
+    <div class="camp-info">
+      <dt>숙박</dt><dd>159,000원</dd>
+      <dt>바베큐</dt><dd>25,000원</dd>
+      <dt>위치</dt><dd>가평군 91km (1시간 49분)</dd>
+      <dt>통행료</dt><dd>6,300원</dd>
+      <dt>연료비</dt><dd>19,000원</dd>
+    </div>
+    <div class="camp-total">총 예상: 209,300원 ⭐ 최저가</div>
+    <div class="camp-tags">
+      <span class="camp-tag">카라반</span>
+      <span class="camp-tag">사우나</span>
+      <span class="camp-tag">고기현장구매필수</span>
+      <span class="camp-tag">특가</span>
+      <span class="camp-tag">호수</span>
+    </div>
+  </div>
+
+  <!-- 달빛정원글램핑 -->
+  <div class="camp-card">
+    <div class="camp-header">
+      <div class="camp-title">🌙 달빛정원글램핑</div>
+      <div class="camp-links">
+        <a class="camp-link camp-link--reserve" href="https://naver.me/5D8t2PFd" target="_blank" rel="noopener">예약</a>
+        <a class="camp-link camp-link--search" href="https://search.naver.com/search.naver?query=%EB%8B%AC%EB%B9%9B%EC%A0%95%EC%9B%90%EA%B8%80%EB%9E%A8%ED%95%91" target="_blank" rel="noopener">네이버</a>
+      </div>
+    </div>
+    <div class="camp-info">
+      <dt>숙박</dt><dd>198,000원</dd>
+      <dt>바베큐</dt><dd>25,000원</dd>
+      <dt>위치</dt><dd>가평군 91km (1시간 32분)</dd>
+      <dt>통행료</dt><dd>5,700원</dd>
+      <dt>연료비</dt><dd>15,000원</dd>
+    </div>
+    <div class="camp-total">총 예상: 243,700원</div>
+    <div class="camp-tags">
+      <span class="camp-tag">글램핑</span>
+      <span class="camp-tag">특가</span>
+      <span class="camp-tag">근처휴양림</span>
+    </div>
+  </div>
+
+  <!-- 리즈밸리글램핑펜션 -->
+  <div class="camp-card">
+    <div class="camp-header">
+      <div class="camp-title">🏔️ 리즈밸리글램핑펜션</div>
+      <div class="camp-links">
+        <a class="camp-link camp-link--reserve" href="https://naver.me/G4WCvFcL" target="_blank" rel="noopener">예약</a>
+        <a class="camp-link camp-link--search" href="https://search.naver.com/search.naver?query=%EB%A6%AC%EC%A6%88%EB%B0%B8%EB%A6%AC%EA%B8%80%EB%9E%A8%ED%95%91%ED%8E%9C%EC%85%98" target="_blank" rel="noopener">네이버</a>
+      </div>
+    </div>
+    <div class="camp-info">
+      <dt>숙박</dt><dd>180,000원</dd>
+      <dt>바베큐</dt><dd>20,000원</dd>
+      <dt>위치</dt><dd>가평군 92km (1시간 33분)</dd>
+      <dt>통행료</dt><dd>5,700원</dd>
+      <dt>연료비</dt><dd>16,000원</dd>
+    </div>
+    <div class="camp-total">총 예상: 221,700원</div>
+    <div class="camp-tags">
+      <span class="camp-tag">카라반</span>
+      <span class="camp-tag">공용샤워시설</span>
+      <span class="camp-tag">계곡</span>
+      <span class="camp-tag">5%할인</span>
+    </div>
+  </div>
+
+  <!-- 해와달수상낚시빌리지 -->
+  <div class="camp-card">
+    <div class="camp-header">
+      <div class="camp-title">🎣 해와달수상낚시빌리지</div>
+      <div class="camp-links">
+        <a class="camp-link camp-link--reserve" href="https://naver.me/GtURueqV" target="_blank" rel="noopener">예약</a>
+        <a class="camp-link camp-link--search" href="https://search.naver.com/search.naver?query=%ED%95%B4%EC%99%80%EB%8B%AC%EC%88%98%EC%83%81%EB%82%9A%EC%8B%9C%EB%B9%8C%EB%A6%AC%EC%A7%80" target="_blank" rel="noopener">네이버</a>
+      </div>
+    </div>
+    <div class="camp-info">
+      <dt>숙박</dt><dd>180,000원</dd>
+      <dt>바베큐</dt><dd>20,000원</dd>
+      <dt>위치</dt><dd>포천시 113km (1시간 36분)</dd>
+      <dt>통행료</dt><dd>5,000원</dd>
+      <dt>연료비</dt><dd>19,500원</dd>
+    </div>
+    <div class="camp-total">총 예상: 224,500원</div>
+    <div class="camp-tags">
+      <span class="camp-tag">글램핑</span>
+      <span class="camp-tag">개별욕실</span>
+      <span class="camp-tag">낚시</span>
+      <span class="camp-tag">바베큐2만원</span>
+      <span class="camp-tag">앞에호수</span>
+    </div>
+  </div>
+
+</div>

--- a/markdown/private/sample.html
+++ b/markdown/private/sample.html
@@ -1,0 +1,8 @@
+<h1>Private Notes 샘플</h1>
+<p>이 문서는 <code>/private</code> 경로에서만 접근할 수 있는 개인 HTML 문서입니다.</p>
+<hr />
+<h2>테스트</h2>
+<ul>
+  <li>HTML 렌더링 확인</li>
+  <li>스타일 적용 확인</li>
+</ul>


### PR DESCRIPTION
## Summary
- `/private` URL로만 접근 가능한 개인 문서 페이지 추가 (메뉴 미노출)
- HTML 파일 기반 렌더링으로 자유로운 문서 작성 지원
- AppBar 숨김 + 간단한 헤더로 모바일 최적화
- 캠핑장 비교 페이지 포함 (라이트/다크 모드 대응)

## Test plan
- [ ] `/private` 목록 페이지 정상 렌더링
- [ ] `/private/camping` 상세 페이지 모바일 뷰 확인
- [ ] 라이트/다크 모드 전환 시 색상 정상 표시
- [ ] AppBar 메뉴에 Private 링크 미노출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)